### PR TITLE
feat: mark messages as read when opening a conversation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             commands::start_monitoring,
             commands::stop_monitoring,
             commands::shutdown_sync_engine,
+            commands::mark_conversation_read,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,15 @@ function App() {
     setSelectedConversation(conversation);
     setIsComposing(false);
     setComposeParticipants([]);
-  }, []);
+
+    // Mark messages as read when opening conversation
+    const cachedId = (conversation as { _cached_id?: number })._cached_id;
+    if (cachedId !== undefined && conversation.unread_count > 0) {
+      api.markConversationRead(cachedId, currentAccount || undefined).catch((err) => {
+        console.error("Failed to mark conversation as read:", err);
+      });
+    }
+  }, [currentAccount]);
 
   const handleCompose = useCallback(() => {
     setSelectedConversation(null);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -181,3 +181,11 @@ export async function hasPendingSyncActions(account?: string): Promise<boolean> 
 export async function shutdownSyncEngine(account?: string): Promise<void> {
   return invoke("shutdown_sync_engine", { account });
 }
+
+/** Mark all unread messages in a conversation as read */
+export async function markConversationRead(
+  conversationId: number,
+  account?: string
+): Promise<void> {
+  return invoke("mark_conversation_read", { account, conversationId });
+}


### PR DESCRIPTION
Add mark_conversation_read Tauri command that:
- Gets unread messages from the conversation
- Updates local database flags (adds \Seen flag)
- Queues AddFlags action for IMAP server sync
- Emits ConversationsUpdated sync event for UI refresh

The UI calls this automatically when selecting a conversation that has unread messages, following the action queue pattern.

https://claude.ai/code/session_014m1UkzPYTCY3XQHNQEWtS9